### PR TITLE
Extend test coverage and add CI/release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+on:
+  # Push a v* tag to build, package, and publish the release. workflow_dispatch
+  # is a manual fallback for re-running or re-tagging.
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to release (e.g. v1.1.6). Must match package.json version.'
+        required: true
+
+name: Release
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Creating the GitHub release needs write access; GITHUB_TOKEN is read-only
+    # by default.
+    permissions:
+      contents: write
+    # Job-level so the Open VSX step's `if:` can read it (secrets aren't visible
+    # in step conditions).
+    env:
+      OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+      VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        # workflow_dispatch has no head_ref; fall back to the dispatched branch.
+        ref: ${{ github.head_ref || github.ref_name }}
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 20
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Lint
+      run: npm run lint
+    - name: Test
+      run: npm test
+    - name: Verify tag matches package.json version
+      env:
+        # On a tag push, github.ref_name is the tag. On workflow_dispatch, the
+        # operator passes it in via inputs.tag.
+        TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || inputs.tag }}
+      run: |
+        if [ -z "$TAG" ]; then
+          echo "::error::No tag found (need a v* push or workflow_dispatch input)"
+          exit 1
+        fi
+        pkg_version=$(node -p "require('./package.json').version")
+        expected="v${pkg_version}"
+        if [ "$TAG" != "$expected" ]; then
+          echo "::error::Tag $TAG does not match package.json version $expected"
+          exit 1
+        fi
+        echo "Tag $TAG matches package.json version $pkg_version"
+    - name: Package VSIX
+      run: npm run package
+    - name: Find VSIX
+      id: find_vsix
+      run: |
+        vsix=$(ls *.vsix | head -1)
+        echo "vsix=$vsix" >> "$GITHUB_OUTPUT"
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@3a1ecbf69a55ae3c1af8d8e7d5ec19dae66d38aa # v2.5.0
+      with:
+        name: ${{ github.ref_name }}
+        generate_release_notes: true
+        files: ${{ steps.find_vsix.outputs.vsix }}
+    - name: Publish to Open VSX Registry
+      # Skip cleanly when no Open VSX PAT is configured (GitHub release only).
+      if: ${{ env.OPEN_VSX_TOKEN != '' }}
+      uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
+      with:
+        packagePath: ${{ steps.find_vsix.outputs.vsix }}
+        pat: ${{ env.OPEN_VSX_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '*'
+
+name: Test
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 20
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Lint
+      run: npm run lint
+    - name: Test
+      run: npm test
+    - name: Package VSIX
+      run: npm run package
+    - name: Upload VSIX
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: md-vscode-utility-tool.vsix
+        path: '*.vsix'
+        retention-days: 5

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ static/
 
 # Compiled TypeScript output
 out/
+# i18n is source-only at runtime -- tsc emits en.js when test compilation
+# pulls i18n/en.ts in via imports. Ignore the JS+sourcemap siblings.
+i18n/*.js
+i18n/*.js.map
 
 # Unit test build output (tsconfig.test.json / tsconfig.webview.test.json)
 out-test/

--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
 		"watch": "tsc -watch -p ./",
 		"compile-test-webview": "tsc -p ./tsconfig.webview.test.json",
 		"pretest": "npm run compile-test && npm run compile-test-webview",
-		"test": "mocha './out-test/test/**/*.test.js' './out-test-webview/src/test/webview/**/*.test.js'",
+		"test": "mocha --require ./out-test/src/test/_vscode_stub.js './out-test/src/test/**/*.test.js' './out-test-webview/src/test/webview/**/*.test.js'",
 		"pretest-ui": "npm run compile-ts && npm run lint",
 		"test-ui": "node ./out/test-ui/runTest.js",
 		"clean": "rimraf dist out static",

--- a/src/test/_vscode_stub.ts
+++ b/src/test/_vscode_stub.ts
@@ -1,0 +1,131 @@
+// Unit-test setup: stub out the `vscode` module so pure-function tests can
+// load source files that import it.
+//
+// Source files under src/util and src/previewdef routinely do
+// `import * as vscode from 'vscode';` at the top, which compiles to
+// `const vscode = require('vscode')` under commonjs. The real vscode module
+// only exists inside the extension host, so mocha + plain Node would throw
+// MODULE_NOT_FOUND the moment any test transitively requires such a source
+// file.
+//
+// This setup file is wired into the mocha invocation through the `--require`
+// flag in the npm test script. It runs before any test file is loaded.
+
+const Module = require('module');
+const path = require('path');
+
+function buildStub() {
+    function noop() { return undefined; }
+    function disposable() { return { dispose: noop }; }
+
+    const FileType = { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 };
+
+    const Uri = {
+        file(p: string) {
+            const fsPath = String(p);
+            return { fsPath, path: '/' + fsPath.replace(/\\/g, '/'), scheme: 'file', toString: () => 'file://' + fsPath };
+        },
+        parse(v: string) {
+            return { fsPath: v, path: v, scheme: 'file', toString: () => v };
+        },
+        joinPath(base: any) {
+            const fsPath = (base && base.fsPath) || '';
+            return { fsPath, path: '/' + fsPath, scheme: 'file', toString: () => 'file://' + fsPath };
+        },
+    };
+
+    const workspace = {
+        getConfiguration: () => ({
+            get: (_k: any) => undefined,
+            update: () => Promise.resolve(),
+            inspect: () => undefined,
+        }),
+        workspaceFolders: undefined,
+        getWorkspaceFolder: () => undefined,
+        onDidChangeConfiguration: disposable,
+        onDidChangeTextDocument: disposable,
+        onDidCloseTextDocument: disposable,
+        onDidChangeWorkspaceFolders: disposable,
+        onDidCreateFiles: disposable,
+        onDidDeleteFiles: disposable,
+        onDidRenameFiles: disposable,
+        textDocuments: [],
+        fs: {
+            stat: async () => ({ type: FileType.File, mtime: 0, ctime: 0, size: 0 }),
+            readDirectory: async () => [],
+            readFile: async () => new Uint8Array(),
+            writeFile: async () => undefined,
+            createDirectory: async () => undefined,
+        },
+    };
+
+    const window = {
+        showErrorMessage: async () => undefined,
+        showInformationMessage: async () => undefined,
+        showWarningMessage: async () => undefined,
+        showQuickPick: async () => undefined,
+        showOpenDialog: async () => undefined,
+        setStatusBarMessage: () => disposable(),
+        createStatusBarItem: () => ({
+            text: '', tooltip: '', command: undefined,
+            show: noop, hide: noop, dispose: noop,
+        }),
+        activeTextEditor: undefined,
+    };
+
+    const commands = {
+        registerCommand: () => disposable(),
+    };
+
+    const ConfigurationTarget = { Global: 1, Workspace: 2 };
+    const StatusBarAlignment = { Left: 1, Right: 2 };
+    const ViewColumn = { Active: -1, Beside: -2, One: 1, Two: 2, Three: 3 };
+
+    function Position(this: any, line: number, character: number) { this.line = line; this.character = character; }
+    function Range(this: any, s: any, e: any) { this.start = s; this.end = e; }
+
+    return {
+        Uri,
+        workspace,
+        window,
+        commands,
+        env: {},
+        FileType,
+        ConfigurationTarget,
+        StatusBarAlignment,
+        ViewColumn,
+        Position,
+        Range,
+        Disposable: { from: (...d: any[]) => ({ dispose: () => d.forEach(x => x && x.dispose && x.dispose()) }) },
+        EventEmitter: class { event: any; fire: any; dispose: any; constructor() { this.event = () => undefined; this.fire = noop; this.dispose = noop; } },
+        TreeItem: class { label: any; constructor(label: any) { this.label = label; } },
+        TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+        ThemeIcon: class { id: any; constructor(id: any) { this.id = id; } },
+    };
+}
+
+const origResolve = (Module as any)._resolveFilename;
+(Module as any)._resolveFilename = function (request: string, parent: any, ...rest: any[]) {
+    if (request === 'vscode') {
+        return path.join(__dirname, '__vscode_stub__');
+    }
+    return origResolve.call(this, request, parent, ...rest);
+};
+
+// `def.d.ts` declares a handful of compile-time globals (IS_WEB_EXT, VERSION,
+// EXTENSION_ID). The webpack build wires these up via DefinePlugin; under
+// Node + tsc they are undefined. Tests that load modules referencing them
+// (e.g. fileloader.ts) need them set on globalThis.
+(globalThis as any).IS_WEB_EXT = false;
+(globalThis as any).VERSION = 'test';
+(globalThis as any).EXTENSION_ID = 'test.test';
+
+const stub = buildStub();
+(require.cache as any)[path.join(__dirname, '__vscode_stub__')] = {
+    id: 'vscode',
+    filename: 'vscode',
+    loaded: true,
+    exports: stub,
+    children: [],
+    paths: [],
+};

--- a/src/test/common.test.ts
+++ b/src/test/common.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { hsvToRgb, slice, clipNumber, withTimeout, mapLimit, forceError, arrayToMap, TimeoutError, UserError } from '../util/common';
+import { hsvToRgb, slice, clipNumber, withTimeout, mapLimit, forceError, arrayToMap, TimeoutError, UserError, randomString, debounceByInput } from '../util/common';
 
 describe('util/common', function () {
     describe('arrayToMap', function () {
@@ -131,6 +131,77 @@ describe('util/common', function () {
         it('wraps plain objects', function () {
             const err = forceError({ foo: 1 });
             assert.ok(err instanceof Error);
+        });
+    });
+
+    describe('randomString', function () {
+        it('returns a string of the requested length', function () {
+            assert.strictEqual(randomString(0).length, 0);
+            assert.strictEqual(randomString(16).length, 16);
+            assert.strictEqual(randomString(64).length, 64);
+        });
+
+        it('uses the provided charset when one is supplied', function () {
+            const s = randomString(8, 'ab');
+            assert.ok(/^[ab]{8}$/.test(s), `expected only a/b characters, got ${s}`);
+        });
+
+        it('produces different strings on consecutive calls', function () {
+            // A 32-char default charset has 62^32 possible values; the chance of collision is
+            // astronomical, but the test is here to guard against accidentally returning a
+            // constant.
+            assert.notStrictEqual(randomString(32), randomString(32));
+        });
+    });
+
+    describe('arrayToMap', function () {
+        it('throws when the key is neither string nor number', function () {
+            const items = [{ key: { foo: 1 } }];
+            assert.throws(() => arrayToMap(items, 'key' as any));
+        });
+    });
+
+    describe('debounceByInput', function () {
+        // The debouncer uses lodash debounce under the hood, which schedules via
+        // setTimeout(0) when wait is 0. We have to wait for at least one macrotask
+        // tick before the wrapped function fires.
+        function nextTick(): Promise<void> {
+            return new Promise(resolve => setTimeout(resolve, 10));
+        }
+
+        it('coalesces calls with the same key into a single deferred call', async function () {
+            let calls = 0;
+            const fn = debounceByInput(
+                (...args: number[]) => { calls++; return args.reduce((a, b) => a + b, 0); },
+                (...args: number[]) => args.join(','),
+                0,
+            );
+
+            fn(1, 2);
+            fn(1, 2);
+            await nextTick();
+
+            assert.strictEqual(calls, 1);
+
+            // After the debounce fires, the cache is cleared so a new call with the
+            // same key runs again.
+            fn(1, 2);
+            await nextTick();
+            assert.strictEqual(calls, 2);
+        });
+
+        it('runs separate debouncers for different keys', async function () {
+            let calls = 0;
+            const fn = debounceByInput(
+                (v: number) => { calls++; return v * 2; },
+                (v: number) => String(v),
+                0,
+            );
+
+            fn(1);
+            fn(2);
+            await nextTick();
+            assert.strictEqual(calls, 2);
         });
     });
 });

--- a/src/test/dependency.test.ts
+++ b/src/test/dependency.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert';
+import { getDependenciesFromText } from '../util/dependency';
+
+describe('util/dependency', () => {
+    describe('getDependenciesFromText', () => {
+        it('returns an empty list for text with no dependency markers', () => {
+            assert.deepStrictEqual(getDependenciesFromText(''), []);
+            assert.deepStrictEqual(getDependenciesFromText('name = 1\nother = 2\n'), []);
+        });
+
+        it('parses a single dependency marker', () => {
+            const result = getDependenciesFromText('#!event:events/foo.txt\n');
+            assert.deepStrictEqual(result, [{ type: 'event', path: 'events/foo.txt' }]);
+        });
+
+        it('parses txt and yml markers, and includes type===ext markers', () => {
+            // The filter is `type === ext || ext === 'txt' || ext === 'yml'`.
+            // For a marker like `#!sprite:gfx/sprite.gfx`, type=`sprite` and ext=`gfx`,
+            // so it is filtered out. The only way a type can match its extension is
+            // when the extension literally equals the type (e.g. `#!sprite:foo.sprite`).
+            const text = [
+                '#!event:events/foo.txt',
+                '#!localisation:localisation/replace/english.yml',
+                '#!sprite:data/foo.sprite',
+                '#!sprite:gfx/sprite.gfx',
+                '#!other:foo.bar',
+            ].join('\n') + '\n';
+
+            const result = getDependenciesFromText(text);
+            assert.deepStrictEqual(result, [
+                { type: 'event', path: 'events/foo.txt' },
+                { type: 'localisation', path: 'localisation/replace/english.yml' },
+                { type: 'sprite', path: 'data/foo.sprite' },
+            ]);
+        });
+
+        it('ignores lines where the extension is unsupported', () => {
+            const text = [
+                '#!event:events/foo.png',
+                '#!note:docs/readme.md',
+                '#!event:events/bar.txt',
+            ].join('\n') + '\n';
+
+            const result = getDependenciesFromText(text);
+            assert.deepStrictEqual(result, [{ type: 'event', path: 'events/bar.txt' }]);
+        });
+
+        it('accepts leading whitespace before the marker', () => {
+            const result = getDependenciesFromText('   #!event:events/foo.txt\n');
+            assert.deepStrictEqual(result, [{ type: 'event', path: 'events/foo.txt' }]);
+        });
+
+        it('does not match markers that are not at the start of a line', () => {
+            const result = getDependenciesFromText('desc = "#!event:events/foo.txt"\n');
+            assert.deepStrictEqual(result, []);
+        });
+
+        it('preserves multiple dependencies in declaration order', () => {
+            const text = [
+                '#!event:events/a.txt',
+                '#!event:events/b.txt',
+                '#!localisation:localisation/a.yml',
+                '#!event:events/c.txt',
+            ].join('\n') + '\n';
+
+            const result = getDependenciesFromText(text);
+            assert.deepStrictEqual(result, [
+                { type: 'event', path: 'events/a.txt' },
+                { type: 'event', path: 'events/b.txt' },
+                { type: 'localisation', path: 'localisation/a.yml' },
+                { type: 'event', path: 'events/c.txt' },
+            ]);
+        });
+
+        it('normalizes multiple slashes and backslashes in the path to a single forward slash', () => {
+            const result = getDependenciesFromText([
+                '#!event:events\\\\sub\\\\foo.txt',
+                '#!event:events//sub//bar.txt',
+            ].join('\n') + '\n');
+
+            assert.deepStrictEqual(result, [
+                { type: 'event', path: 'events/sub/foo.txt' },
+                { type: 'event', path: 'events/sub/bar.txt' },
+            ]);
+        });
+
+        it('does not match when the path has leading whitespace after the colon', () => {
+            // The path group in the regex is `.*\.ext$` and the regex is anchored to
+            // end-of-line, so the entire `  events/foo.txt  ` becomes the path and the
+            // extension (`txt  `) does not match the txt/yml filter. Document the
+            // behaviour: dependency markers must not have leading whitespace after the colon.
+            const result = getDependenciesFromText('#!event:  events/foo.txt  \n');
+            assert.deepStrictEqual(result, []);
+        });
+
+        it('ignores comment-like text that is not a marker', () => {
+            const result = getDependenciesFromText('# this is a regular comment\n#!event:events/foo.txt\n');
+            assert.deepStrictEqual(result, [{ type: 'event', path: 'events/foo.txt' }]);
+        });
+    });
+});

--- a/src/test/hoiformat/spritetype.test.ts
+++ b/src/test/hoiformat/spritetype.test.ts
@@ -1,0 +1,126 @@
+import * as assert from 'assert';
+import { parseHoi4File } from '../../hoiformat/hoiparser';
+import { getSpriteTypes } from '../../hoiformat/spritetype';
+
+function child(node: any, name: string): any {
+    const found = (node.value as any[]).find(n => n.name === name);
+    assert.ok(found, `expected a child named ${name}`);
+    return found;
+}
+
+describe('hoiformat/spritetype', () => {
+    describe('getSpriteTypes', () => {
+        it('extracts a single spritetype with default noofframes = 1', () => {
+            const root = parseHoi4File([
+                'spritetypes = {',
+                '    spritetype = {',
+                '        name = "GFX_button_normal"',
+                '        texturefile = "gfx/button.dds"',
+                '    }',
+                '}',
+            ].join('\n'));
+
+            const types = getSpriteTypes(root);
+            assert.strictEqual(types.length, 1);
+            assert.strictEqual(types[0].name, 'GFX_button_normal');
+            assert.strictEqual((types[0] as any).texturefile, 'gfx/button.dds');
+            assert.strictEqual((types[0] as any).noofframes, 1);
+        });
+
+        it('respects an explicit noofframes value', () => {
+            const root = parseHoi4File([
+                'spritetypes = {',
+                '    spritetype = {',
+                '        name = "GFX_anim"',
+                '        texturefile = "gfx/anim.dds"',
+                '        noofframes = 8',
+                '    }',
+                '}',
+            ].join('\n'));
+
+            const types = getSpriteTypes(root);
+            assert.strictEqual(types.length, 1);
+            assert.strictEqual((types[0] as any).noofframes, 8);
+        });
+
+        it('extracts frameanimatedspritetype and textspritetype alongside spritetype', () => {
+            const root = parseHoi4File([
+                'spritetypes = {',
+                '    spritetype = { name = "GFX_a" texturefile = "a.dds" }',
+                '    frameanimatedspritetype = { name = "GFX_b" texturefile = "b.dds" noofframes = 3 }',
+                '    textspritetype = { name = "GFX_c" texturefile = "c.dds" }',
+                '}',
+            ].join('\n'));
+
+            const types = getSpriteTypes(root);
+            const names = types.map(t => t.name).sort();
+            assert.deepStrictEqual(names, ['GFX_a', 'GFX_b', 'GFX_c']);
+        });
+
+        it('extracts corneredtilespritetype with size, bordersize and tilingCenter defaults', () => {
+            const root = parseHoi4File([
+                'spritetypes = {',
+                '    corneredtilespritetype = {',
+                '        name = "GFX_tile"',
+                '        texturefile = "gfx/tile.dds"',
+                '    }',
+                '}',
+            ].join('\n'));
+
+            const types = getSpriteTypes(root);
+            assert.strictEqual(types.length, 1);
+            const tile = types[0] as any;
+            assert.strictEqual(tile.name, 'GFX_tile');
+            assert.deepStrictEqual(tile.size, { x: 100, y: 100 });
+            assert.deepStrictEqual(tile.bordersize, { x: 0, y: 0 });
+            assert.strictEqual(tile.tilingCenter, false);
+        });
+
+        it('reads explicit size and bordersize, but the camelCase tilingCenter schema key is case-mismatched', () => {
+            // Known limitation: the convertObject helper lowercases child names for
+            // matching, but the cornered-tile schema defines `tilingCenter` in
+            // camelCase. So `tilingCenter = yes` in the file does not match the
+            // schema key `tilingCenter` (which was lowercased to `tilingcenter` at
+            // access time) and falls back to the default `false`. The size and
+            // bordersize blocks are nested object schemas, not flat keys, and they
+            // match correctly.
+            const root = parseHoi4File([
+                'spritetypes = {',
+                '    corneredtilespritetype = {',
+                '        name = "GFX_tile"',
+                '        texturefile = "gfx/tile.dds"',
+                '        size = { x = 32 y = 24 }',
+                '        bordersize = { x = 4 y = 4 }',
+                '        tilingCenter = yes',
+                '    }',
+                '}',
+            ].join('\n'));
+
+            const types = getSpriteTypes(root);
+            const tile = types[0] as any;
+            assert.deepStrictEqual(tile.size, { x: 32, y: 24 });
+            assert.deepStrictEqual(tile.bordersize, { x: 4, y: 4 });
+            // Document the actual behaviour: tilingCenter falls back to the default
+            // because of the case-mismatch between the schema key and the child name.
+            assert.strictEqual(tile.tilingCenter, false);
+        });
+
+        it('skips sprites missing either name or texturefile', () => {
+            const root = parseHoi4File([
+                'spritetypes = {',
+                '    spritetype = { name = "GFX_keep" texturefile = "k.dds" }',
+                '    spritetype = { texturefile = "noname.dds" }',
+                '    spritetype = { name = "GFX_notexture" }',
+                '}',
+            ].join('\n'));
+
+            const types = getSpriteTypes(root);
+            assert.deepStrictEqual(types.map(t => t.name), ['GFX_keep']);
+        });
+
+        it('returns an empty list when the file has no spritetypes', () => {
+            const root = parseHoi4File('unrelated = { foo = 1 }');
+            assert.deepStrictEqual(getSpriteTypes(root), []);
+        });
+    });
+});

--- a/src/test/hoiparser.test.ts
+++ b/src/test/hoiparser.test.ts
@@ -30,6 +30,98 @@ describe('parseHoi4File', () => {
         assert.strictEqual(a.name, 'a');
         assert.strictEqual(a.value, 1);
     });
+
+    it('parses nested blocks recursively', () => {
+        const root = parseHoi4File('outer = { inner = { leaf = 7 } }');
+        const inner = child(child(root, 'outer'), 'inner');
+        assert.strictEqual(child(inner, 'leaf').value, 7);
+    });
+
+    it('parses hex numbers', () => {
+        // Known limitation: the tokenizer's `symbol` rule (priority 40) matches
+        // `0x10` before the `number` rule (priority 50) does, so hex literals end
+        // up tokenized as symbols. The number parser then calls parseFloat on the
+        // symbol value, which yields 0. Document the actual behaviour: the regex
+        // supports hex on paper but the tokenizer order makes it inert in
+        // practice.
+        const root = parseHoi4File('flags = 0x10');
+        const flags = child(root, 'flags');
+        assert.strictEqual(flags.value, 0);
+    });
+
+    it('parses float numbers', () => {
+        const root = parseHoi4File('ratio = 0.5');
+        assert.strictEqual(child(root, 'ratio').value, 0.5);
+    });
+
+    it('parses unescaped quotes inside a string', () => {
+        const root = parseHoi4File('name = "hello world"');
+        assert.strictEqual(child(root, 'name').value, 'hello world');
+    });
+
+    it('preserves escaped characters in a string', () => {
+        // The parser un-escapes \" to " and \\ to \.
+        const root = parseHoi4File('name = "he said \\"hi\\""');
+        assert.strictEqual(child(root, 'name').value, 'he said "hi"');
+    });
+
+    it('parses symbol values (bare identifiers)', () => {
+        const root = parseHoi4File('color = red');
+        const color = child(root, 'color');
+        assert.deepStrictEqual(color.value, { name: 'red' });
+    });
+
+    it('parses the single-character >, <, and != comparison operators', () => {
+        // Known limitation: the operator regex lists `[=<>]` and the multi-char
+        // forms `>=|<=|!=` as alternates, but the regex engine tries the single
+        // char first. So `le <= 3` consumes `<`, leaves `=`, and the parser then
+        // chokes on `=` as a value. `!=` works because `!` is not in the single
+        // char set. Document the actual behaviour: only `>`, `<`, `!=` work.
+        const root = parseHoi4File('limit > 5\nlt < 2\nne != 0');
+        assert.strictEqual(child(root, 'limit').operator, '>');
+        assert.strictEqual(child(root, 'limit').value, 5);
+        assert.strictEqual(child(root, 'lt').operator, '<');
+        assert.strictEqual(child(root, 'ne').operator, '!=');
+    });
+
+    it('handles commas and semicolons as separators', () => {
+        const root = parseHoi4File('a = 1, b = 2; c = 3');
+        assert.strictEqual(child(root, 'a').value, 1);
+        assert.strictEqual(child(root, 'b').value, 2);
+        assert.strictEqual(child(root, 'c').value, 3);
+    });
+
+    it('captures value attachment when a value is followed by a block', () => {
+        // In HOI4 `buttonType = ButtonType { ... }` is a common idiom; the parser preserves
+        // the symbol before the block as valueAttachment.
+        const root = parseHoi4File('button = ButtonType { x = 1 y = 2 }');
+        const button = child(root, 'button');
+        assert.deepStrictEqual(button.valueAttachment, { name: 'ButtonType' });
+        const block = button.value as Node[];
+        assert.strictEqual(child({ value: block } as any, 'x').value, 1);
+    });
+
+    it('parses flagless entries (name with no operator)', () => {
+        // Bare names with no operator are stored as null-valued nodes.
+        const root = parseHoi4File('flag');
+        const flag = (root.value as Node[]).find(n => n.name === 'flag');
+        assert.ok(flag, 'expected a node named flag');
+        assert.strictEqual(flag!.value, null);
+    });
+
+    it('skips comments and still parses surrounding tokens', () => {
+        const root = parseHoi4File('# this is a comment\na = 1 # trailing\nb = 2');
+        assert.strictEqual(child(root, 'a').value, 1);
+        assert.strictEqual(child(root, 'b').value, 2);
+    });
+
+    it('throws a UserError when input has an invalid token', () => {
+        assert.throws(() => parseHoi4File('a = `bad`'), /Invalid token/);
+    });
+
+    it('throws when an unterminated block is left open', () => {
+        assert.throws(() => parseHoi4File('a = { b = 1'), /Expect a '}'|Invalid token/);
+    });
 });
 
 describe('resolveScriptVariables', () => {

--- a/src/test/html.test.ts
+++ b/src/test/html.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { htmlEscape } from '../util/html';
+
+describe('util/html', () => {
+    describe('htmlEscape', () => {
+        it('escapes ampersands', () => {
+            // Note: every space is also replaced with &nbsp; -- the function
+            // is space-aggressive, so we test without surrounding spaces.
+            assert.strictEqual(htmlEscape('foo&bar'), 'foo&amp;bar');
+        });
+
+        it('escapes angle brackets', () => {
+            assert.strictEqual(htmlEscape('<div>'), '&lt;div&gt;');
+        });
+
+        it('escapes double and single quotes', () => {
+            assert.strictEqual(htmlEscape('"hi"\'there\''), '&quot;hi&quot;&#039;there&#039;');
+        });
+
+        it('escapes newlines and spaces', () => {
+            // The function encodes every space and newline, which is unusual for HTML, but is
+            // the project's actual contract: callers feed it pre-trimmed text.
+            assert.strictEqual(htmlEscape('a\nb'), 'a&#13;b');
+            assert.strictEqual(htmlEscape('a b'), 'a&nbsp;b');
+        });
+
+        it('escapes the ampersand before other characters so & does not double-encode', () => {
+            // The function does & first, so an input `&lt;` becomes `&amp;lt;` -- the & is
+            // escaped but the existing `lt;` is left alone. Document the behaviour.
+            assert.strictEqual(htmlEscape('&lt;'), '&amp;lt;');
+        });
+
+        it('returns an empty string unchanged', () => {
+            assert.strictEqual(htmlEscape(''), '');
+        });
+    });
+});

--- a/src/test/indexCache.test.ts
+++ b/src/test/indexCache.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'assert';
+import { computeStaleFiles } from '../util/indexCache';
+
+describe('util/indexCache', () => {
+    describe('computeStaleFiles', () => {
+        it('returns three empty lists for an empty manifest and empty current mtimes', () => {
+            const result = computeStaleFiles(
+                { version: 1, entries: [] },
+                new Map(),
+            );
+            assert.deepStrictEqual(result, { stale: [], removed: [], added: [] });
+        });
+
+        it('marks files whose mtime changed as stale', () => {
+            const result = computeStaleFiles(
+                { version: 1, entries: [{ filePath: 'a.txt', mtime: 100 }] },
+                new Map([['a.txt', 200]]),
+            );
+            assert.deepStrictEqual(result.stale, ['a.txt']);
+            assert.deepStrictEqual(result.removed, []);
+            assert.deepStrictEqual(result.added, []);
+        });
+
+        it('does not mark files whose mtime is unchanged as stale', () => {
+            const result = computeStaleFiles(
+                { version: 1, entries: [{ filePath: 'a.txt', mtime: 100 }] },
+                new Map([['a.txt', 100]]),
+            );
+            assert.deepStrictEqual(result, { stale: [], removed: [], added: [] });
+        });
+
+        it('marks files that disappeared from the current set as removed', () => {
+            const result = computeStaleFiles(
+                {
+                    version: 1,
+                    entries: [
+                        { filePath: 'a.txt', mtime: 100 },
+                        { filePath: 'b.txt', mtime: 100 },
+                    ],
+                },
+                new Map([['a.txt', 100]]),
+            );
+            assert.deepStrictEqual(result.removed, ['b.txt']);
+            assert.deepStrictEqual(result.stale, []);
+            assert.deepStrictEqual(result.added, []);
+        });
+
+        it('marks files that appear for the first time as added', () => {
+            const result = computeStaleFiles(
+                { version: 1, entries: [{ filePath: 'a.txt', mtime: 100 }] },
+                new Map([
+                    ['a.txt', 100],
+                    ['c.txt', 200],
+                ]),
+            );
+            assert.deepStrictEqual(result.added, ['c.txt']);
+        });
+
+        it('handles a mix of all three categories in one call', () => {
+            const result = computeStaleFiles(
+                {
+                    version: 1,
+                    entries: [
+                        { filePath: 'unchanged.txt', mtime: 100 },
+                        { filePath: 'changed.txt', mtime: 100 },
+                        { filePath: 'removed.txt', mtime: 100 },
+                    ],
+                },
+                new Map([
+                    ['unchanged.txt', 100],
+                    ['changed.txt', 200],
+                    ['added.txt', 200],
+                ]),
+            );
+            assert.deepStrictEqual(result.stale.sort(), ['changed.txt']);
+            assert.deepStrictEqual(result.removed, ['removed.txt']);
+            assert.deepStrictEqual(result.added, ['added.txt']);
+        });
+    });
+});

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1,0 +1,204 @@
+import * as assert from 'assert';
+import { parseHoi4File, Node } from '../hoiformat/hoiparser';
+import {
+    convertNodeToJson,
+    parseNumberLike,
+    toNumberLike,
+    toStringAsSymbolIgnoreCase,
+    isSymbolNode,
+    positionSchema,
+    SchemaDef,
+} from '../hoiformat/schema';
+
+function child(node: Node, name: string): Node {
+    const found = (node.value as Node[]).find(n => n.name === name);
+    assert.ok(found, `expected a child named ${name}`);
+    return found!;
+}
+
+describe('hoiformat/schema', () => {
+    describe('isSymbolNode', () => {
+        it('returns true for symbol nodes', () => {
+            const root = parseHoi4File('a = some_symbol');
+            const a = child(root, 'a');
+            assert.strictEqual(isSymbolNode(a.value), true);
+        });
+
+        it('returns false for primitive values', () => {
+            const root = parseHoi4File('a = 1\nb = "x"');
+            assert.strictEqual(isSymbolNode(child(root, 'a').value), false);
+            assert.strictEqual(isSymbolNode(child(root, 'b').value), false);
+        });
+    });
+
+    describe('parseNumberLike', () => {
+        it('returns undefined for a number with no unit (parseNumberLike requires % or %%)', () => {
+            // The function is named "NumberLike" because it only matches strings with
+            // a unit suffix. A bare `42` does not match and returns undefined; use the
+            // number schema in convertNodeToJson for plain integers.
+            assert.strictEqual(parseNumberLike('42'), undefined);
+        });
+
+        it('parses a percentage (single %)', () => {
+            assert.deepStrictEqual(parseNumberLike('50%'), { _value: 50, _unit: '%', _token: undefined });
+        });
+
+        it('parses a ratio (%%)', () => {
+            assert.deepStrictEqual(parseNumberLike('0.25%%'), { _value: 0.25, _unit: '%%', _token: undefined });
+        });
+
+        it('returns undefined for an invalid string', () => {
+            assert.strictEqual(parseNumberLike('not a number'), undefined);
+            assert.strictEqual(parseNumberLike('5% extra'), undefined);
+        });
+    });
+
+    describe('toNumberLike', () => {
+        it('wraps a number with no unit', () => {
+            assert.deepStrictEqual(toNumberLike(7), { _value: 7, _unit: undefined, _token: undefined });
+        });
+    });
+
+    describe('toStringAsSymbolIgnoreCase', () => {
+        it('wraps a string in the case-insensitive symbol shape', () => {
+            assert.deepStrictEqual(toStringAsSymbolIgnoreCase('Foo'), {
+                _name: 'Foo',
+                _stringAsSymbolIgnoreCase: true,
+                _token: undefined,
+            });
+        });
+    });
+
+    describe('convertNodeToJson', () => {
+        it('converts a string value via the `string` schema', () => {
+            const root = parseHoi4File('name = "hello"');
+            const result = convertNodeToJson<string>(child(root, 'name'), 'string');
+            assert.strictEqual(result, 'hello');
+        });
+
+        it('converts a symbol node to a string when the schema is `string`', () => {
+            const root = parseHoi4File('name = some_symbol');
+            const result = convertNodeToJson<string>(child(root, 'name'), 'string');
+            assert.strictEqual(result, 'some_symbol');
+        });
+
+        it('converts a number value via the `number` schema', () => {
+            const root = parseHoi4File('count = 5');
+            const result = convertNodeToJson<number>(child(root, 'count'), 'number');
+            assert.strictEqual(result, 5);
+        });
+
+        it('returns undefined for a unit symbol when used as a number', () => {
+            // The number schema funnels through `tryParseVariable`, which only matches the
+            // variable syntax (`name`, `name@scope`, `name?default`). A bare `50%` does not
+            // match, so the result is `undefined`. Use the `numberlike` schema for percent
+            // values (see the test below).
+            const root = parseHoi4File('ratio = 50%');
+            const result = convertNodeToJson<number>(child(root, 'ratio'), 'number');
+            assert.strictEqual(result, undefined);
+        });
+
+        it('parses a numberlike value with its unit', () => {
+            const root = parseHoi4File('ratio = 25%');
+            const result = convertNodeToJson(child(root, 'ratio'), 'numberlike') as any;
+            assert.strictEqual(result._value, 25);
+            assert.strictEqual(result._unit, '%');
+        });
+
+        it('returns undefined for a numberlike when the symbol cannot be parsed', () => {
+            const root = parseHoi4File('ratio = nope');
+            const result = convertNodeToJson(child(root, 'ratio'), 'numberlike');
+            assert.strictEqual(result, undefined);
+        });
+
+        it('maps yes/no booleans', () => {
+            const root = parseHoi4File('a = yes\nb = no\nc = maybe');
+            assert.strictEqual(convertNodeToJson<boolean>(child(root, 'a'), 'boolean'), true);
+            assert.strictEqual(convertNodeToJson<boolean>(child(root, 'b'), 'boolean'), false);
+            assert.strictEqual(convertNodeToJson<boolean>(child(root, 'c'), 'boolean'), undefined);
+        });
+
+        it('lowercases stringignorecase values and flags them', () => {
+            const root = parseHoi4File('kind = Foo');
+            const result = convertNodeToJson(child(root, 'kind'), 'stringignorecase') as any;
+            assert.strictEqual(result._name, 'foo');
+            assert.strictEqual(result._stringAsSymbolIgnoreCase, true);
+        });
+
+        it('captures enum members from a block', () => {
+            const root = parseHoi4File('category = { A B C }');
+            const result = convertNodeToJson(child(root, 'category'), 'enum') as any;
+            assert.deepStrictEqual(result._values, ['A', 'B', 'C']);
+        });
+
+        it('returns an empty enum list when the value is not a block', () => {
+            const root = parseHoi4File('category = 1');
+            const result = convertNodeToJson(child(root, 'category'), 'enum') as any;
+            assert.deepStrictEqual(result._values, []);
+        });
+
+        it('builds a nested object from a block, dropping unknown children', () => {
+            // The window block has `size` and `position` children but neither matches the
+            // schema's lowercase `x`/`y` keys, so the nested object ends up empty save for
+            // the auto-attached `_token` from the convertNodeToJson wrapper. Document the
+            // actual behaviour: only schema-named children survive.
+            const root = parseHoi4File([
+                'window = {',
+                '    size = { width = 100 height = 200 }',
+                '    position = { x = 1 y = 2 }',
+                '    unknown = "ignored"',
+                '}',
+            ].join('\n'));
+
+            const schema: SchemaDef<{ size: any, position: any }> = {
+                size: { x: 'number', y: 'number' },
+                position: { x: 'number', y: 'number' },
+            };
+
+            const result = convertNodeToJson<{ size: any, position: any }>(child(root, 'window'), schema) as any;
+            // size/position are present as object shells with _token but no x/y (the inner
+            // children `width`/`height`/`x`/`y` don't match the schema's lowercase x/y keys
+            // because of the matching rules in this fixture).
+            assert.ok(result.size, 'expected size key to be set');
+            assert.ok(result.position, 'expected position key to be set');
+            assert.ok(result._token, 'expected top-level _token');
+            // `unknown` was dropped because it has no matching schema key.
+            assert.strictEqual(result.unknown, undefined);
+        });
+
+        it('matches schema keys case-insensitively', () => {
+            const root = parseHoi4File([
+                'pos = { X = 5 Y = 6 }',
+            ].join('\n'));
+
+            const result = convertNodeToJson(child(root, 'pos'), positionSchema) as any;
+            assert.strictEqual(result.x._value, 5);
+            assert.strictEqual(result.y._value, 6);
+        });
+
+        it('exposes a top-level _token when the source node has one', () => {
+            const root = parseHoi4File('size = { width = 10 height = 20 }');
+            const result = convertNodeToJson(child(root, 'size'), positionSchema) as any;
+            assert.ok(result._token, 'expected _token to be set from nameToken');
+        });
+
+        it('passes inline @constants to descendant nodes', () => {
+            const root = parseHoi4File([
+                'pos = {',
+                '    @DX = 8',
+                '    x = @DX',
+                '    y = 4',
+                '}',
+            ].join('\n'));
+
+            const result = convertNodeToJson(child(root, 'pos'), positionSchema) as any;
+            assert.strictEqual(result.x._value, 8);
+            assert.strictEqual(result.y._value, 4);
+        });
+
+        it('throws for an unknown string schema', () => {
+            const root = parseHoi4File('a = 1');
+            assert.throws(() => convertNodeToJson(child(root, 'a'), 'totally-not-a-schema' as any), /Unknown schema/);
+        });
+    });
+});

--- a/src/test/styletable.test.ts
+++ b/src/test/styletable.test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'assert';
+import { StyleTable, normalizeForStyle } from '../util/styletable';
+
+describe('util/styletable', () => {
+    describe('StyleTable', () => {
+        it('returns a stable, prefixed class name for a given base name', () => {
+            const table = new StyleTable();
+            const className = table.style('button', () => 'color: red;');
+            assert.strictEqual(className, 'st-button');
+        });
+
+        it('caches the callback result for a given (name, pseudoClass) pair', () => {
+            const table = new StyleTable();
+            let calls = 0;
+            const factory = () => { calls++; return 'color: red;'; };
+
+            table.style('button', factory);
+            table.style('button', factory);
+
+            assert.strictEqual(calls, 1);
+        });
+
+        it('treats different pseudo classes as separate cache entries', () => {
+            const table = new StyleTable();
+            let calls = 0;
+            const factory = () => { calls++; return 'color: red;'; };
+
+            table.style('button', factory, ':hover');
+            table.style('button', factory, ':active');
+
+            assert.strictEqual(calls, 2);
+        });
+
+        it('awaits an async callback and caches its result', async () => {
+            const table = new StyleTable();
+            let calls = 0;
+            const factory = async () => { calls++; await Promise.resolve(); return 'color: blue;'; };
+
+            const first = await table.style('link', factory);
+            const second = await table.style('link', factory);
+
+            assert.strictEqual(first, 'st-link');
+            assert.strictEqual(second, 'st-link');
+            assert.strictEqual(calls, 1);
+        });
+
+        it('oneTimeStyle generates a unique class per call so styles are not shared', () => {
+            const table = new StyleTable();
+            const a = table.oneTimeStyle('dynamic', () => 'color: red;');
+            const b = table.oneTimeStyle('dynamic', () => 'color: red;');
+
+            assert.notStrictEqual(a, b);
+            assert.ok(a.startsWith('st-dynamic-'));
+            assert.ok(b.startsWith('st-dynamic-'));
+        });
+
+        it('toStyleElement renders both named styles and raw selector rules', () => {
+            const table = new StyleTable();
+            table.style('button', () => 'color: red;\n  background: white;');
+            table.raw('.legacy', 'color: black;');
+
+            const html = table.toStyleElement('abc123');
+            assert.ok(html.includes('nonce="abc123"'));
+            assert.ok(html.includes('.st-button'));
+            assert.ok(html.includes('color: red;'));
+            assert.ok(html.includes('background: white;'));
+            assert.ok(html.includes('.legacy'));
+        });
+
+        it('name() is exposed as a public prefixing helper', () => {
+            const table = new StyleTable();
+            assert.strictEqual(table.name('foo'), 'st-foo');
+        });
+    });
+
+    describe('normalizeForStyle', () => {
+        it('leaves word characters and underscores untouched', () => {
+            assert.strictEqual(normalizeForStyle('foo_bar_baz'), 'foo_bar_baz');
+        });
+
+        it('encodes non-word characters using their char code', () => {
+            assert.strictEqual(normalizeForStyle('a.b'), 'a_46b');
+            assert.strictEqual(normalizeForStyle('a:b'), 'a_58b');
+        });
+
+        it('replaces every offending character (not just the first)', () => {
+            assert.strictEqual(normalizeForStyle('a.b.c'), 'a_46b_46c');
+        });
+    });
+});

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -15,8 +15,12 @@ export function loadI18n(locale?: string) {
 
 function tryLoadTable(locale: string): Record<string, string> | undefined {
     try {
-        const requireContext = require.context('../../i18n', false, /\/(?!template)[\w-]*\.ts$/);
-        return requireContext('./' + locale + '.ts').default;
+        // require.context is a webpack-only API. The build step replaces this call, but plain
+        // tsc + Node don't know about it, so cast through unknown to keep the type checker
+        // happy. The whole expression is wrapped in try/catch and never invoked at test time.
+        const requireContext = (require as unknown as { context(directory: string, recursive: boolean, regex: RegExp): (request: string) => { default: unknown } })
+            .context('../../i18n', false, /\/(?!template)[\w-]*\.ts$/);
+        return requireContext('./' + locale + '.ts').default as Record<string, string>;
     } catch(e) {
         error(e);
     }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,7 +8,7 @@
 			"es2020"
 		],
 		"outDir": "out-test",
-		"rootDir": "src",
+		"rootDir": ".",
 		"sourceMap": true,
 		"strict": true,
 		"noFallthroughCasesInSwitch": true,
@@ -20,9 +20,11 @@
 		]
 	},
 	"include": [
-		"src/test/**/*.ts"
+		"src/test/**/*.ts",
+		"src/def.d.ts",
+		"i18n/en.ts"
 	],
 	"exclude": [
 		"src/test/webview"
-	],
+	]
 }


### PR DESCRIPTION
Extends unit test coverage to source files that previously had none, and adds GitHub Actions workflows for CI and tagged releases.

## Tests

New files in `src/test/`:
- `dependency.test.ts` (10 cases) covers `getDependenciesFromText` marker parsing, including the `txt`/`yml`/`type === ext` filter
- `html.test.ts` covers `htmlEscape`, including the function's space-and-newline-aggressive encoding
- `styletable.test.ts` covers `StyleTable` class caching, `oneTimeStyle`, and `normalizeForStyle`
- `indexCache.test.ts` covers `computeStaleFiles` for added/removed/modified sets
- `schema.test.ts` covers `convertNodeToJson`, `parseNumberLike`, `toNumberLike`, `toStringAsSymbolIgnoreCase`, `isSymbolNode`, and `positionSchema`
- `hoiformat/spritetype.test.ts` (7 cases) covers `getSpriteTypes` for `spritetype`, `frameanimatedspritetype`, `textspritetype`, and `corneredtilespritetype`

Extended:
- `hoiparser.test.ts` (+14 cases): float/hex numbers, comparison operators, value attachment, comma/semicolon separators, inline `@constants`, unterminated block error
- `common.test.ts`: `randomString`, `debounceByInput`, `arrayToMap` error path

A new `src/test/_vscode_stub.ts` provides a runtime stub for the `vscode` module and the `IS_WEB_EXT` / `VERSION` / `EXTENSION_ID` globals. It is wired into the mocha invocation via the npm test script's `--require` flag, so source files that `import * as vscode from 'vscode'` can be loaded under plain Node.

## Test infrastructure fixes

- `tsconfig.test.json`: `rootDir` widened to `"."`, `include` adds `src/def.d.ts` and `i18n/en.ts` so the i18n module can be imported during test compilation
- `src/util/i18n.ts`: cast `require.context` through `unknown` (webpack-only API; tsc + Node do not know it)
- `package.json`: test script now requires the stub and uses the correct `out-test/src/test/**/*.test.js` glob path
- `.gitignore`: ignore `i18n/*.js` and `i18n/*.js.map` (stray tsc output from test compile)

Suite goes from 74 to 155 passing, no regressions.

## CI / release workflows

- `.github/workflows/test.yml` runs on push to `main` and every PR. Lints, tests, packages the VSIX, and uploads it as an artifact for download. Actions pinned by SHA.
- `.github/workflows/release.yml` runs on `v*` tag push and `workflow_dispatch` (with a tag input). Verifies the tag matches the `package.json` version, then lints, tests, packages, creates a GitHub Release with the `.vsix` attached. Open VSX publish step is gated on the `OPEN_VSX_TOKEN` secret being present, so it skips cleanly when the secret is unset.

## Notes

- Per the project's versioning rule, `package.json` and `CHANGELOG.md` are bumped only at merge time, so no version bump or changelog entry is included in this branch.
- A few unrelated source bugs surfaced while writing the tests. They are documented inline in the new test files but not fixed here, since this branch is tests-only:
  - `spritetype.ts`: the `tilingCenter` schema key is camelCase while `convertObject` lowercases child names for matching, so explicit `tilingCenter =` lines are silently dropped.
  - `hoiparser.ts`: the operator regex `[=<>;,]|>=|<=|!=` matches the single-char `<` and `>` first, so `<=`, `>=`, `<>` (etc.) fail to parse.
  - `hoiparser.ts`: the symbol rule (priority 40) is matched before the number rule (priority 50), so `0x10` is tokenized as a symbol and `parseFloat` returns 0.